### PR TITLE
add dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: node_js
+node_js:
+  - "5"

--- a/index.js
+++ b/index.js
@@ -1,22 +1,19 @@
 'use strict';
 
 var ProtoMessages = require('connect-protobuf-messages');
-var connectJsApi = require('connect-js-api');
-var AdapterTLS = connectJsApi.AdapterTLS;
-var EncodeDecode = connectJsApi.EncodeDecode;
-var Connect = connectJsApi.Connect;
+var AdapterTLS = require('connect-js-adapter-tls');
+var EncodeDecode = require('connect-js-encode-decode');
+var Connect = require('connect-js-api');
 var ping = require('./lib/ping');
 var auth = require('./lib/auth');
 var subscribeForSpots = require('./lib/subscribe_for_spots');
 var startTime;
 var protocol = new ProtoMessages([
     {
-        file: 'node_modules/connect-protobuf-messages/src/main/protobuf/CommonMessages.proto',
-        protoPayloadType: 'ProtoPayloadType'
+        file: 'node_modules/connect-protobuf-messages/src/main/protobuf/CommonMessages.proto'
     },
     {
-        file: 'node_modules/connect-protobuf-messages/src/main/protobuf/OpenApiMessages.proto',
-        protoPayloadType: 'ProtoOAPayloadType'
+        file: 'node_modules/connect-protobuf-messages/src/main/protobuf/OpenApiMessages.proto'
     }
 ]);
 var adapter = new AdapterTLS({

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "start": "node index"
   },
   "dependencies": {
+    "connect-js-adapter-tls": "spotware/connect-js-adapter-tls",
     "connect-js-api": "spotware/connect-js-api#2.1.0",
+    "connect-js-encode-decode": "spotware/connect-js-encode-decode",
     "connect-protobuf-messages": "spotware/connect-protobuf-messages"
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "connect-js-adapter-tls": "spotware/connect-js-adapter-tls",
-    "connect-js-api": "spotware/connect-js-api#2.1.0",
+    "connect-js-api": "spotware/connect-js-api",
     "connect-js-encode-decode": "spotware/connect-js-encode-decode",
     "connect-protobuf-messages": "spotware/connect-protobuf-messages"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "connect-nodejs-samples",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Samples of using Spotware Connect Open API in JavaScript and Node.js",
   "keywords": [
     "spotware",


### PR DESCRIPTION
AdapterTLS & EncodeDecode have been moved from connect-js-api to standalone packages.
They should be using as:

``` js
require('connect-js-adapter-tls');
require('connect-js-encode-decode');
```

Using last version of connect-js-api package
