### PR TITLE
switch dependency "connect-protobuf-messages" from master to stable a…

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,6 @@
     "connect-js-adapter-tls": "spotware/connect-js-adapter-tls#v1.0.0",
     "connect-js-api": "spotware/connect-js-api#v2.5.1",
     "connect-js-encode-decode": "spotware/connect-js-encode-decode",
-    "connect-protobuf-messages": "spotware/connect-protobuf-messages"
+    "connect-protobuf-messages": "spotware/connect-protobuf-messages#v2.0.0"
   }
 }


### PR DESCRIPTION
_Duplicate name in namespace Namespace : ProtoTradeSide #13_

This package dependence on [connect-protobuf-messages](https://github.com/spotware/connect-protobuf-messages) (code from master branch). Now required repository is [broken](https://travis-ci.org/spotware/connect-protobuf-messages/builds/250363583) after commit: [Trading API changes](https://github.com/spotware/connect-protobuf-messages/commit/2810bf26a1e9762a57209186b4e78bd581323ef1).
Last release [v2.0.0](https://github.com/spotware/connect-protobuf-messages/releases/tag/v2.0.0) is tested and stable.

This PR switch [connect-protobuf-messages](https://github.com/spotware/connect-protobuf-messages) from master to [v2.0.0](https://github.com/spotware/connect-protobuf-messages/releases/tag/v2.0.0).